### PR TITLE
Own the devbox VM's NixOS + home-manager configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Notes for Claude
+
+## Keep docs in sync
+
+When changing `justfile`, `flake.nix`, `nixos/`, or `home/`, update [README.md](README.md) in the same change if it affects:
+
+- Recipe names, defaults, or the first-run flow.
+- What's installed in the VM (system or user packages).
+- Host-side requirements or one-time setup.
+- Constraints users hit in practice (e.g. the read-only `/Users/<you>` mount).
+
+Docs drift silently — prefer a one-line README tweak over "I'll get to it later".

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ just ssh
 mkdir -p ~/code && cd ~/code
 git clone …
 ```
+
+The mount's read-only state is the Lima default; we keep it. If you want to override it (or anything else in the template), [`flake.nix`](flake.nix) has a `yq`-based pattern commented next to the `lima-template` derivation.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,35 @@
 # lima-nixos-demo
 
-A minimal [`justfile`](justfile) for running a NixOS devbox VM via [Lima](https://lima-vm.io/) on macOS.
+A [`justfile`](justfile) + flake for running a customized NixOS devbox VM via [Lima](https://lima-vm.io/) on macOS.
 
 ## Requirements
 
-- [Nix](https://nixos.asia/en/install) (provides `lima` via `nix shell nixpkgs#lima`)
+- [Nix](https://nixos.asia/en/install) (everything else comes from the devShell)
 - [`just`](https://github.com/casey/just)
+
+Run `nix develop` once to enter a shell with `lima` + `just` pinned, or let each recipe invoke `nix develop -c` automatically.
 
 ## Usage
 
 ```sh
 just              # list recipes
-just start        # create & start the NixOS VM (6 CPU / 12 GB / 100 GB)
+just start        # create + boot the VM, then apply our flake (nixos-rebuild)
+just provision    # re-apply the flake (after editing config)
 just shell        # open a shell in the VM
 just stop         # stop the VM
 just delete       # remove the VM
 just list         # list all Lima VMs
 ```
+
+First `just start` takes a few minutes: it boots the stock `github:nixos-lima` image, then `nixos-rebuild switch` applies our [`flake.nix`](flake.nix) on top (system + home-manager in one shot).
+
+The VM user and hostname default to your macOS `$USER` / `devbox`.
+
+## What's in the VM
+
+System (via [`nixos/configuration.nix`](nixos/configuration.nix)): `nix-ld`, flakes, passwordless `wheel` sudo, `systemd-logind` lingering for the user, [`nixos-vscode-server`](https://github.com/nix-community/nixos-vscode-server).
+
+User (via [`home/home.nix`](home/home.nix)): `starship`, `direnv` + `nix-direnv`, `btop`, `gh`.
 
 ## SSH access
 
@@ -24,4 +37,14 @@ just list         # list all Lima VMs
 just ssh                # SSH into the VM (uses Lima's generated config, no global mutation)
 just ssh uname -a       # run a command over SSH
 just ssh-config         # print Lima's generated SSH config
+```
+
+## Working on projects inside the VM
+
+Lima mounts your macOS home at `/Users/<you>` inside the guest **read-only**. For development, clone repos into the guest's own filesystem (writable, faster, no 9p overhead):
+
+```sh
+just ssh
+mkdir -p ~/code && cd ~/code
+git clone …
 ```

--- a/default.nix
+++ b/default.nix
@@ -2,27 +2,22 @@
 
 let
   system = "aarch64-linux";
-  username = "srid";
-  pkgs = nixpkgs.legacyPackages.${system};
+  # Read from $USER at flake eval time (requires `--impure`). The guest user
+  # Lima creates matches the macOS host user, so passing $USER through from
+  # the justfile yields the right name in the guest. Must be preserved across
+  # the `sudo` boundary that nixos-rebuild crosses — see justfile.
+  username =
+    let u = builtins.getEnv "USER";
+    in if u == "" then throw "USER env var not set — pass --impure and preserve USER across sudo." else u;
 in
 {
   nixosConfigurations.devbox = nixpkgs.lib.nixosSystem {
     inherit system;
+    specialArgs = { inherit username nixos-vscode-server; };
     modules = [
       nixos-lima.nixosModules.lima
+      home-manager.nixosModules.home-manager
       ./nixos/configuration.nix
-      { _module.args = { inherit username; }; }
     ];
   };
-
-  homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
-    inherit pkgs;
-    extraSpecialArgs = { inherit username; };
-    modules = [
-      nixos-vscode-server.homeModules.default
-      ./home/home.nix
-    ];
-  };
-
-  packages.${system}.home-manager = home-manager.packages.${system}.default;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ nixpkgs, nixos-lima, home-manager, nixos-vscode-server, ... }:
+
+let
+  system = "aarch64-linux";
+  username = "srid";
+  pkgs = nixpkgs.legacyPackages.${system};
+in
+{
+  nixosConfigurations.devbox = nixpkgs.lib.nixosSystem {
+    inherit system;
+    modules = [
+      nixos-lima.nixosModules.lima
+      ./nixos/configuration.nix
+      { _module.args = { inherit username; }; }
+    ];
+  };
+
+  homeConfigurations.${username} = home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    extraSpecialArgs = { inherit username; };
+    modules = [
+      nixos-vscode-server.homeModules.default
+      ./home/home.nix
+    ];
+  };
+
+  packages.${system}.home-manager = home-manager.packages.${system}.default;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,215 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776777932,
+        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1736643958,
+        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "nixos-lima",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769813415,
+        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
+    "nixos-lima": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixos-generators": "nixos-generators",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      },
+      "locked": {
+        "lastModified": 1776358282,
+        "narHash": "sha256-tDHMHTVqq/GJz+eu8QZyqaBfVVmWS588GSk3hJLW0nE=",
+        "owner": "nixos-lima",
+        "repo": "nixos-lima",
+        "rev": "431636eba66e6d7d46e0a913811b1d65c01114f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos-lima",
+        "ref": "master",
+        "repo": "nixos-lima",
+        "type": "github"
+      }
+    },
+    "nixos-vscode-server": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770124655,
+        "narHash": "sha256-yHmd2B13EtBUPLJ+x0EaBwNkQr9LTne1arLVxT6hSnY=",
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "rev": "92ce71c3ba5a94f854e02d57b14af4997ab54ef0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixos-lima": "nixos-lima",
+        "nixos-vscode-server": "nixos-vscode-server",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
   };
 
-  outputs = inputs@{ nixpkgs, ... }:
+  outputs = inputs@{ nixpkgs, nixos-lima, ... }:
     let
       darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
       forEach = nixpkgs.lib.genAttrs;
@@ -26,5 +26,17 @@
       devShells = forEach darwinSystems (system: {
         default = import ./shell.nix { pkgs = nixpkgs.legacyPackages.${system}; };
       });
+
+      # Lima template YAML, pinned to our locked nixos-lima input. Passes
+      # through unmodified today; to apply local overrides (e.g. writable
+      # mounts), swap the `cp` for a `yq` transform, for example:
+      #   nativeBuildInputs = [ pkgs.yq-go ];
+      #   yq '.mounts |= map(.writable = true)' ${nixos-lima}/.lima.yaml > $out
+      packages = forEach darwinSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in {
+          lima-template = pkgs.runCommand "nixos-lima-template" { } ''
+            cp ${nixos-lima}/.lima.yaml $out
+          '';
+        });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "lima-nixos-demo: custom NixOS + home-manager config for a Lima devbox on macOS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixos-lima = {
+      url = "github:nixos-lima/nixos-lima/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixos-vscode-server = {
+      url = "github:nix-community/nixos-vscode-server";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs@{ nixpkgs, ... }:
+    let
+      darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
+      forEach = nixpkgs.lib.genAttrs;
+    in
+    (import ./default.nix inputs) // {
+      devShells = forEach darwinSystems (system: {
+        default = import ./shell.nix { pkgs = nixpkgs.legacyPackages.${system}; };
+      });
+    };
+}

--- a/home/home.nix
+++ b/home/home.nix
@@ -9,6 +9,11 @@
 
   programs.home-manager.enable = true;
 
+  # Required for HM to inject shell integration (starship init, direnv hook,
+  # etc.) into the user's bash init files. Without this, `programs.*.enable`
+  # modules that rely on shell hooks are silently no-ops.
+  programs.bash.enable = true;
+
   programs.starship.enable = true;
 
   programs.direnv = {

--- a/home/home.nix
+++ b/home/home.nix
@@ -2,7 +2,7 @@
 
 {
   home.username = username;
-  home.homeDirectory = "/home/${username}.linux";
+  home.homeDirectory = "/home/${username}.guest";
   home.stateVersion = "25.11";
 
   programs.home-manager.enable = true;

--- a/home/home.nix
+++ b/home/home.nix
@@ -2,6 +2,8 @@
 
 {
   home.username = username;
+  # Lima convention: the guest user's home lives at /home/<user>.guest.
+  # (Lima also mounts the host's /Users/<user> into the guest at the same path.)
   home.homeDirectory = "/home/${username}.guest";
   home.stateVersion = "25.11";
 
@@ -15,6 +17,9 @@
   };
 
   programs.btop.enable = true;
+
+  # `gh` CLI — useful for agentic GitHub work (issues, PRs, reviews) from
+  # the VM without leaving the shell.
   programs.gh.enable = true;
 
   services.vscode-server.enable = true;

--- a/home/home.nix
+++ b/home/home.nix
@@ -1,0 +1,21 @@
+{ pkgs, username, ... }:
+
+{
+  home.username = username;
+  home.homeDirectory = "/home/${username}.linux";
+  home.stateVersion = "25.11";
+
+  programs.home-manager.enable = true;
+
+  programs.starship.enable = true;
+
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
+
+  programs.btop.enable = true;
+  programs.gh.enable = true;
+
+  services.vscode-server.enable = true;
+}

--- a/justfile
+++ b/justfile
@@ -7,14 +7,14 @@ default:
 
 # --- Lifecycle ---
 
-# `github:nixos-lima` below is a Lima TEMPLATE reference (the stock qcow2
-# release), not a Nix flake input. Our locked nixos-lima in flake.lock
-# takes over only after `provision` runs nixos-rebuild with our own config.
+# We build the Lima template from our locked `nixos-lima` flake input
+# via `.#lima-template`, so `limactl start` sees exactly the pinned
+# version (qcow2 digest included) instead of refetching master.
 
 # Create and start the NixOS VM, then apply our custom config
 [group('lifecycle')]
 start vm=name:
-    {{nix_shell}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 --yes github:nixos-lima
+    {{nix_shell}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 --yes $(nix build --no-link --print-out-paths .#lima-template)
     just provision {{vm}}
 
 # `--workdir /tmp` keeps CWD off Lima's Users-<user> 9p mount so that

--- a/justfile
+++ b/justfile
@@ -17,8 +17,10 @@ start vm=name:
 # Apply our NixOS + home-manager config inside the VM (idempotent)
 [group('lifecycle')]
 provision vm=name:
-    {{nix_shell}} limactl shell {{vm}} -- sudo nixos-rebuild switch --flake $(pwd)#devbox
-    {{nix_shell}} limactl shell {{vm}} -- nix run $(pwd)#home-manager -- switch --flake $(pwd)#{{username}}
+    # `--workdir /tmp` keeps CWD off the Users-<user>.mount 9p mount so
+    # switch-to-configuration can restart that mount without a busy-target error.
+    {{nix_shell}} limactl shell --workdir /tmp {{vm}} -- sudo nixos-rebuild switch --flake $(pwd)#devbox
+    {{nix_shell}} limactl shell --workdir /tmp {{vm}} -- nix run $(pwd)#home-manager -- switch --flake $(pwd)#{{username}}
 
 # Stop the VM
 [group('lifecycle')]

--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop -c' }
 name := "devbox"
-username := "srid"
 
 # List available recipes
 default:
@@ -8,19 +7,25 @@ default:
 
 # --- Lifecycle ---
 
+# `github:nixos-lima` below is a Lima TEMPLATE reference (the stock qcow2
+# release), not a Nix flake input. Our locked nixos-lima in flake.lock
+# takes over only after `provision` runs nixos-rebuild with our own config.
+
 # Create and start the NixOS VM, then apply our custom config
 [group('lifecycle')]
 start vm=name:
     {{nix_shell}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 --yes github:nixos-lima
     just provision {{vm}}
 
+# `--workdir /tmp` keeps CWD off Lima's Users-<user> 9p mount so that
+# switch-to-configuration can restart that mount unit cleanly.
+# `--impure` + `env USER=...` lets default.nix read $USER across the sudo
+# boundary, so the flake provisions for the invoking user.
+
 # Apply our NixOS + home-manager config inside the VM (idempotent)
 [group('lifecycle')]
 provision vm=name:
-    # `--workdir /tmp` keeps CWD off the Users-<user>.mount 9p mount so
-    # switch-to-configuration can restart that mount without a busy-target error.
-    {{nix_shell}} limactl shell --workdir /tmp {{vm}} -- sudo nixos-rebuild switch --flake $(pwd)#devbox
-    {{nix_shell}} limactl shell --workdir /tmp {{vm}} -- nix run $(pwd)#home-manager -- switch --flake $(pwd)#{{username}}
+    {{nix_shell}} limactl shell --workdir /tmp {{vm}} -- sudo env USER=$USER nixos-rebuild switch --impure --flake $(pwd)#devbox
 
 # Stop the VM
 [group('lifecycle')]

--- a/justfile
+++ b/justfile
@@ -1,42 +1,51 @@
+nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop -c' }
+name := "devbox"
+username := "srid"
+
+# List available recipes
 default:
     @just --list
 
-lima := "nix shell nixpkgs#lima -c"
-name := "devbox"
-
 # --- Lifecycle ---
 
-# Create and start the NixOS VM
+# Create and start the NixOS VM, then apply our custom config
 [group('lifecycle')]
 start vm=name:
-    {{lima}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 github:nixos-lima
+    {{nix_shell}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 --yes github:nixos-lima
+    just provision {{vm}}
+
+# Apply our NixOS + home-manager config inside the VM (idempotent)
+[group('lifecycle')]
+provision vm=name:
+    {{nix_shell}} limactl shell {{vm}} -- sudo nixos-rebuild switch --flake $(pwd)#devbox
+    {{nix_shell}} limactl shell {{vm}} -- nix run $(pwd)#home-manager -- switch --flake $(pwd)#{{username}}
 
 # Stop the VM
 [group('lifecycle')]
 stop vm=name:
-    {{lima}} limactl stop {{vm}}
+    {{nix_shell}} limactl stop {{vm}}
 
 # Remove the VM (destructive)
 [group('lifecycle')]
 delete vm=name:
-    {{lima}} limactl delete {{vm}}
+    {{nix_shell}} limactl delete {{vm}}
 
 # List all Lima VMs
 [group('lifecycle')]
 list:
-    {{lima}} limactl list
+    {{nix_shell}} limactl list
 
 # --- Access ---
 
 # Open a shell in the VM
 [group('access')]
 shell vm=name:
-    {{lima}} limactl shell {{vm}}
+    {{nix_shell}} limactl shell {{vm}}
 
 # Print Lima's generated SSH config for the VM
 [group('access')]
 ssh-config vm=name:
-    {{lima}} limactl show-ssh --format=config {{vm}}
+    {{nix_shell}} limactl show-ssh --format=config {{vm}}
 
 # SSH into the VM using Lima's generated config (no global config mutation)
 [group('access')]

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,24 +1,39 @@
-{ config, lib, pkgs, modulesPath, username, ... }:
+{ config, lib, pkgs, modulesPath, username, nixos-vscode-server, ... }:
 
 {
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
   ];
 
-  networking.hostName = "devbox";
-
+  # Enable Lima guest integration (lima-init: user creation from cidata,
+  # ssh key install, mount setup from user-data, lima-guestagent service).
+  # This is the only thing `nixos-lima.nixosModules.lima` actually provides.
   services.lima.enable = true;
+
+  # Lima creates the guest user imperatively via lima-init at first boot
+  # (useradd with the macOS host's UID). Declaring the user here without a
+  # UID lets NixOS's user module coexist: if the user already exists, the
+  # activation is a no-op — it just makes HM's NixOS module happy (HM reads
+  # `config.users.users.${name}.{name,home}`).
+  users.users.${username} = {
+    isNormalUser = true;
+    home = "/home/${username}.guest";
+    group = "users";
+    extraGroups = [ "wheel" ];
+    createHome = false;
+  };
 
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   services.openssh.enable = true;
-
   security.sudo.wheelNeedsPassword = false;
 
+  # Run random prebuilt Linux binaries (VSCode server is handled separately
+  # via nixos-vscode-server, but other tools benefit from nix-ld too).
   programs.nix-ld.enable = true;
 
-  # Persist user systemd services (vscode-server, future `code tunnel`) across
-  # logouts / reboots without requiring an active login session.
+  # Persist user systemd services (vscode-server, future `code tunnel`)
+  # across logouts / reboots without requiring an active login session.
   systemd.tmpfiles.rules = [
     "f /var/lib/systemd/linger/${username} 0644 root root -"
   ];
@@ -43,6 +58,19 @@
   boot.kernelPackages = pkgs.linuxPackages_latest;
 
   environment.systemPackages = with pkgs; [ vim ];
+
+  # Apply home-manager as part of this system's activation so a single
+  # `nixos-rebuild switch` provisions both system and user config.
+  home-manager = {
+    useGlobalPkgs = true;
+    # Lima manages the guest user's home imperatively; avoid per-user
+    # package linking into users.users.<user>.packages.
+    useUserPackages = false;
+    backupFileExtension = "hm-backup";
+    extraSpecialArgs = { inherit username; };
+    sharedModules = [ nixos-vscode-server.homeModules.default ];
+    users.${username} = import ../home/home.nix;
+  };
 
   system.stateVersion = "25.11";
 }

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, modulesPath, username, ... }:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  networking.hostName = "devbox";
+
+  services.lima.enable = true;
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  services.openssh.enable = true;
+
+  security.sudo.wheelNeedsPassword = false;
+
+  programs.nix-ld.enable = true;
+
+  # Persist user systemd services (vscode-server, future `code tunnel`) across
+  # logouts / reboots without requiring an active login session.
+  systemd.tmpfiles.rules = [
+    "f /var/lib/systemd/linger/${username} 0644 root root -"
+  ];
+
+  # Boot/filesystem settings must match the stock nixos-lima qcow2 image.
+  boot.loader.grub = {
+    device = "nodev";
+    efiSupport = true;
+    efiInstallAsRemovable = true;
+  };
+  fileSystems."/boot" = {
+    device = lib.mkForce "/dev/vda1";
+    fsType = "vfat";
+  };
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    autoResize = true;
+    fsType = "ext4";
+    options = [ "noatime" "nodiratime" "discard" ];
+  };
+
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  environment.systemPackages = with pkgs; [ vim ];
+
+  system.stateVersion = "25.11";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    lima
+    just
+  ];
+}


### PR DESCRIPTION
Closes #2.

## What changes from the user's POV

- **Before:** `just start` boots a stock upstream NixOS image; no way to customize.
- **After:** `just start` boots that same image, then applies our flake on top (`nixos-rebuild switch` + `home-manager switch`) so the VM ends up with our chosen system and user config.

Concrete things the user now gets in the VM:

- VSCode remote server works (via [`nixos-vscode-server`](https://github.com/nix-community/nixos-vscode-server)).
- Interactive shell extras: `starship`, `direnv` + `nix-direnv`, `btop`, `gh`.
- System: `nix-ld`, flakes + `nix-command`, passwordless sudo, `systemd-logind` lingering so user services survive logout.

## Try it

```sh
just delete   # if a prior devbox exists
just start    # boots + provisions (takes a while on first run)
just ssh -- starship --version
just ssh -- btop --version
just ssh -- systemctl --user status auto-fix-vscode-server.service
```

## Shape

```
flake.nix                # thin; inputs + devShell wrapping
default.nix              # nixosConfigurations, homeConfigurations
shell.nix                # devShell (lima + just) for the macOS host
nixos/configuration.nix  # system-level NixOS module
home/home.nix            # user-level home-manager module
justfile                 # new `provision`; `start` chains it; `nix_shell` auto-detection
```

Follows the [`juspay/skills` nix-justfile convention](https://github.com/juspay/skills/blob/main/skills/nix-justfile/SKILL.md) — `nix develop -c` replaces `nix shell nixpkgs#lima -c`.