### PR TITLE
Document VSCode Remote-SSH setup; add just to home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The VM user and hostname default to your macOS `$USER` / `devbox`.
 
 System (via [`nixos/configuration.nix`](nixos/configuration.nix)): `nix-ld`, flakes, passwordless `wheel` sudo, `systemd-logind` lingering for the user, [`nixos-vscode-server`](https://github.com/nix-community/nixos-vscode-server).
 
-User (via [`home/home.nix`](home/home.nix)): `starship`, `direnv` + `nix-direnv`, `btop`, `gh`.
+User (via [`home/home.nix`](home/home.nix)): `starship`, `direnv` + `nix-direnv`, `btop`, `just`, `gh`.
 
 ## SSH access
 
@@ -38,6 +38,15 @@ just ssh                # SSH into the VM (uses Lima's generated config, no glob
 just ssh uname -a       # run a command over SSH
 just ssh-config         # print Lima's generated SSH config
 ```
+
+## VSCode Remote-SSH
+
+Point VSCode at Lima's generated SSH config — no `~/.ssh/config` mutation, no tunnel service:
+
+1. `Cmd-Shift-P` → **Remote-SSH: Settings** → set **Config File** to `~/.lima/devbox/ssh.config`.
+2. `Cmd-Shift-P` → **Remote-SSH: Connect to Host…** → pick `lima-devbox`.
+
+That's the whole setup. Subsequent connects are one command.
 
 ## Working on projects inside the VM
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -23,6 +23,8 @@
 
   programs.btop.enable = true;
 
+  programs.just.enable = true;
+
   # `gh` CLI — useful for agentic GitHub work (issues, PRs, reviews) from
   # the VM without leaving the shell.
   programs.gh.enable = true;


### PR DESCRIPTION
## Summary

- Add a **VSCode Remote-SSH** section to the README: point VSCode's `remote.SSH.configFile` at `~/.lima/devbox/ssh.config` via the Remote-SSH settings UI (Cmd-Shift-P). No `~/.ssh/config` mutation, no tunnel service, no `code` CLI wrapper — two Cmd-Shift-P commands and done.
- Enable \`programs.just\` in home-manager so recipes are available inside the guest too.

Closes #3.

## Test plan

- [ ] \`just start\` boots the VM and \`just provision\` applies the new config.
- [ ] \`just ssh which just\` returns a Nix-store path.
- [ ] In VSCode: Cmd-Shift-P → "Remote-SSH: Settings" → set Config File to \`~/.lima/devbox/ssh.config\` → Cmd-Shift-P → "Remote-SSH: Connect to Host…" → \`lima-devbox\` opens a remote window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)