### PR TITLE
Autodetect VM cpus/memory/disk from host; add `just recreate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ just list         # list all Lima VMs
 
 First `just start` takes a few minutes: it boots the stock `github:nixos-lima` image, then `nixos-rebuild switch` applies our [`flake.nix`](flake.nix) on top (system + home-manager in one shot).
 
-The VM user and hostname default to your macOS `$USER` / `devbox`. CPU / memory / disk default to `6` cores, `host RAM − 4 GiB`, and `half of host free disk`. Memory is a ceiling (the vz driver demand-pages from the host); disk is a ceiling (Lima's qcow2 is sparse and grows lazily). Override any default with `just --set`, e.g. `just --set memory 16 --set disk 200 start`.
+The VM user and hostname default to your macOS `$USER` / `devbox`. CPU / memory / disk default to `host cores − 2`, `host RAM − 4 GiB`, and `half of host free disk`. Memory is a ceiling (the vz driver demand-pages from the host); disk is a ceiling (Lima's qcow2 is sparse and grows lazily); CPU over-subscription is cheap. Override any default with `just --set`, e.g. `just --set cpus 4 --set memory 16 --set disk 200 start`.
 
 ## What's in the VM
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ just provision    # re-apply the flake (after editing config)
 just shell        # open a shell in the VM
 just stop         # stop the VM
 just delete       # remove the VM
+just recreate     # wipe and start fresh
 just list         # list all Lima VMs
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ just list         # list all Lima VMs
 
 First `just start` takes a few minutes: it boots the stock `github:nixos-lima` image, then `nixos-rebuild switch` applies our [`flake.nix`](flake.nix) on top (system + home-manager in one shot).
 
-The VM user and hostname default to your macOS `$USER` / `devbox`.
+The VM user and hostname default to your macOS `$USER` / `devbox`. CPU / memory / disk default to `6` cores, `host RAM − 4 GiB`, and `half of host free disk`. Memory is a ceiling (the vz driver demand-pages from the host); disk is a ceiling (Lima's qcow2 is sparse and grows lazily). Override any default with `just --set`, e.g. `just --set memory 16 --set disk 200 start`.
 
 ## What's in the VM
 

--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop -c' }
 name := "devbox"
-cpus := "6"
+
+# CPUs = host logical cores − 2 (leave a couple for the host). CPU
+# over-subscription is cheap — the host scheduler time-slices — so we
+# can be generous. Override: `just --set cpus 4 start`.
+cpus := `echo $(( $(sysctl -n hw.ncpu) - 2 ))`
 
 # Memory ceiling in GiB = host RAM − 4 GiB. With the vz driver the host
 # demand-pages guest memory, so this is a cap, not an up-front allocation.

--- a/justfile
+++ b/justfile
@@ -48,6 +48,12 @@ stop vm=name:
 delete vm=name:
     {{nix_shell}} limactl delete {{vm}}
 
+# Wipe the VM and start fresh (leading `-` tolerates a non-existent VM)
+[group('lifecycle')]
+recreate vm=name:
+    -{{nix_shell}} limactl delete --force {{vm}}
+    just start {{vm}}
+
 # List all Lima VMs
 [group('lifecycle')]
 list:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,16 @@
 nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop -c' }
 name := "devbox"
+cpus := "6"
+
+# Memory ceiling in GiB = host RAM − 4 GiB. With the vz driver the host
+# demand-pages guest memory, so this is a cap, not an up-front allocation.
+# Override: `just --set memory 16 start`.
+memory := `echo $(( $(sysctl -n hw.memsize) / 1073741824 - 4 ))`
+
+# Disk ceiling in GiB = half of host root-fs free space. Lima's qcow2 is
+# sparse, so the image only grows as the guest writes.
+# Override: `just --set disk 200 start`.
+disk := `echo $(( $(df -k / | awk 'NR==2 {print $4}') / 1024 / 1024 / 2 ))`
 
 # List available recipes
 default:
@@ -14,7 +25,7 @@ default:
 # Create and start the NixOS VM, then apply our custom config
 [group('lifecycle')]
 start vm=name:
-    {{nix_shell}} limactl start --name={{vm}} --cpus=6 --memory=12 --disk=100 --yes $(nix build --no-link --print-out-paths .#lima-template)
+    {{nix_shell}} limactl start --name={{vm}} --cpus={{cpus}} --memory={{memory}} --disk={{disk}} --yes $(nix build --no-link --print-out-paths .#lima-template)
     just provision {{vm}}
 
 # `--workdir /tmp` keeps CWD off Lima's Users-<user> 9p mount so that


### PR DESCRIPTION
## Summary

- `just start` now picks sensible defaults from the host:
  - **cpus** = host logical cores − 2 (CPU over-subscription is cheap).
  - **memory** = host RAM − 4 GiB (vz driver demand-pages, so this is a ceiling, not an up-front allocation).
  - **disk** = half of host root-fs free space (Lima's qcow2 is sparse and grows lazily as the guest writes).
- Override any of them without editing the justfile, e.g. `just --set cpus 4 --set memory 16 --set disk 200 start`.
- New `just recreate` — wipes the VM (`limactl delete --force`, tolerating a non-existent VM) and chains into `just start`.

On my 10-core / 64 GiB Mac with ~2.2 TiB free, `just --evaluate` now reports `cpus := "8"`, `memory := "60"`, `disk := "1129"`.

## Test plan

- [ ] `just --evaluate` shows non-zero `cpus` / `memory` / `disk` values on macOS.
- [ ] `just start` still boots the VM with the new `--cpus` / `--memory` / `--disk` flags.
- [ ] `just --set memory 8 start` overrides the default.
- [ ] Post-boot, `nproc` / `free -g` / `df -h /` inside the VM reflect the ceilings.
- [ ] `just recreate` on a running VM wipes and reboots it; on a non-existent VM, it skips the delete error and starts fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)