### PR TITLE
Fix: install just via home.packages (programs.just removed in HM)

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -23,11 +23,11 @@
 
   programs.btop.enable = true;
 
-  programs.just.enable = true;
-
   # `gh` CLI — useful for agentic GitHub work (issues, PRs, reviews) from
   # the VM without leaving the shell.
   programs.gh.enable = true;
 
   services.vscode-server.enable = true;
+
+  home.packages = [ pkgs.just ];
 }


### PR DESCRIPTION
## Summary

Home Manager master removed the `programs.just` module (it's now a no-op assertion: *"no longer has any effect; please remove it"*), breaking `just provision`. Swap to `home.packages = [ pkgs.just ];` — we weren't relying on HM's shell integration anyway.

## Test plan

- [ ] `just provision` on the VM completes without the `programs.just.enable` assertion error.
- [ ] `just ssh which just` returns a Nix-store path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)