### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # macOS-only: our flake targets aarch64-linux inside the VM, but builds
+  # nothing on Linux runners. Darwin hosts can still eval the NixOS config
+  # (Nix evaluation is cross-system) and actually build the darwin outputs.
+  check:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      # --impure is required because default.nix reads $USER via
+      # builtins.getEnv (the runner sets USER=runner, which is fine).
+      - name: nix flake check
+        run: nix flake check --impure --show-trace
+
+      - name: build lima-template
+        run: nix build --no-link --print-out-paths .#lima-template
+
+      - name: verify devShell + justfile parse
+        run: nix develop --command just --list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: nixbuild/nix-quick-install-action@v34
         with:
-          extra_nix_config: |
+          nix_conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
 


### PR DESCRIPTION
## Summary

Single macos-latest (arm64) job:

- `nix flake check --impure` — catches eval regressions across the NixOS config, HM module, and darwin outputs. `--impure` is needed because `default.nix` reads `$USER` via `builtins.getEnv` (runner sets `USER=runner`, which is fine).
- `nix build .#lima-template` — exercises the pinned Lima template derivation.
- `nix develop --command just --list` — verifies the devShell and the justfile parse cleanly.

Linux runners are skipped — our NixOS config targets aarch64-linux and we don't cross-build it here.

## Test plan

- [ ] Workflow runs green on this PR.
- [ ] A deliberately broken flake (e.g. undefined attr) fails `flake check`.
- [ ] A deliberately broken justfile fails the `just --list` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)