### PR TITLE
chore: add conventional commit release tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,31 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 jobs:
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: x86_64-linux
+    steps:
+      - name: Check Conventional Commit PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._-]+\))?(!)?: .+'
+          if [[ ! "$TITLE" =~ $pattern ]]; then
+            cat >&2 <<'EOF'
+          PR titles must follow Conventional Commits because squash merges create the commit history.
+
+          Examples:
+            feat: boot devbox from release image
+            fix(lima): clear mutable dev image cache
+            docs: document release workflow
+          EOF
+            exit 1
+          fi
+
   check:
     runs-on: x86_64-linux
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,14 @@ When changing `justfile`, `flake.nix`, `nixos/`, or `home/`, update [README.md](
 - Constraints users hit in practice (e.g. the read-only `/Users/<you>` mount).
 
 Docs drift silently — prefer a one-line README tweak over "I'll get to it later".
+
+## Conventional Commits
+
+Use Conventional Commit titles for commits and pull requests. This repo uses
+squash merges, so the PR title becomes the commit title and release-note input.
+
+Examples:
+
+- `feat: boot devbox from release image`
+- `fix(lima): clear mutable dev image cache`
+- `docs: document release workflow`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ After merging release-image changes, create a GitHub release:
 just release v0.1.0
 ```
 
-Publishing the release starts the `Release Images` workflow. The workflow builds and compresses the x86_64 image on the self-hosted `x86_64-linux` runner and the aarch64 image on GitHub's `ubuntu-24.04-arm` runner, then uploads the qcow2, SHA-512, and Lima template assets to the release.
+`just release` generates release notes from Conventional Commits since the latest tag, creates the GitHub release, and starts the `Release Images` workflow. The workflow builds and compresses the x86_64 image on the self-hosted `x86_64-linux` runner and the aarch64 image on GitHub's `ubuntu-24.04-arm` runner, then uploads the qcow2, SHA-512, and Lima template assets to the release.
+
+To preview the generated notes:
+
+```sh
+just release-notes v0.1.1
+```
 
 For PR testing, use the mutable dev prerelease:
 
@@ -56,6 +62,18 @@ just release-development
 ```
 
 That recreates the `dev` release at the current branch and dispatches the image workflow on that branch. Its assets are overwritten on each run, so use it only for disposable testing.
+
+## Conventional Commits
+
+This repo uses squash merges, so PR titles should follow Conventional Commits. The merged commit title becomes the release-note input.
+
+Use types like `feat`, `fix`, `docs`, `ci`, `build`, `refactor`, `test`, and `chore`, with an optional scope:
+
+```text
+feat: boot devbox from release image
+fix(lima): clear mutable dev image cache
+docs: document release workflow
+```
 
 ## Security model
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,40 @@
+# git-cliff release note configuration.
+# Commit history is created by squash-merging PRs, so PR titles should follow
+# Conventional Commits.
+
+[changelog]
+body = """{%- for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+render_always = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+require_conventional = false
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+fail_on_unmatched_commit = false
+topo_order = false
+topo_order_commits = true
+sort_commits = "oldest"
+
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactors" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Tests" },
+  { message = "^build", group = "Build" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", group = "Chores" },
+  { message = "^style", group = "Style" },
+  { message = "^revert", group = "Reverts" },
+]

--- a/justfile
+++ b/justfile
@@ -101,10 +101,20 @@ ssh *args='':
 
 # --- Release ---
 
+# Print release notes generated from Conventional Commits since the latest tag
+[group('release')]
+release-notes version:
+    @{{nix_shell}} git cliff --unreleased --tag "{{version}}" --strip header
+
 # Create a GitHub release and start image uploads
 [group('release')]
 release version:
-    {{nix_shell}} gh release create "{{version}}" --repo juspay/devbox --target main --title "Release {{version}}" --notes "Devbox image release {{version}}"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    notes_file="$(mktemp)"
+    trap 'rm -f "$notes_file"' EXIT
+    {{nix_shell}} git cliff --unreleased --tag "{{version}}" --strip header > "$notes_file"
+    {{nix_shell}} gh release create "{{version}}" --repo juspay/devbox --target main --title "Release {{version}}" --notes-file "$notes_file"
     {{nix_shell}} gh workflow run release-images.yml --repo juspay/devbox --ref main -f tag="{{version}}"
 
 # Recreate the mutable dev prerelease from the current branch

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 
 pkgs.mkShell {
   packages = with pkgs; [
+    git-cliff
     gh
     lima
     just


### PR DESCRIPTION
## Summary

- add git-cliff configuration for Conventional Commit release notes
- add `just release-notes` and have `just release` use generated notes
- check PR titles in CI because squash merges create the commit history
- document the Conventional Commit workflow in the README

## Validation

- `just release-notes v0.1.1`
- `just --summary`
- `nix shell --inputs-from . nixpkgs#actionlint --command actionlint -ignore 'label ".*" is unknown'`
- `nix flake check --show-trace`
- `git diff --check`
