### PR TITLE
fix(security): restrict default host mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ limactl start --name=devbox https://github.com/juspay/devbox/releases/latest/dow
 limactl shell --workdir=. devbox
 ```
 
-Use `--workdir=.` when opening a shell. The template intentionally has a transfer mount, so plain `limactl shell devbox` makes Lima try to enter your macOS current directory inside the guest. That path is not mounted.
+Use `--workdir=.` when opening a shell. Because the template mounts host `/tmp/lima-devbox` at guest `/tmp/lima-devbox`, plain `limactl shell devbox` makes Lima try to enter your macOS current directory inside the guest. That path is not mounted.
 
 ## What's in the VM
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ First `just start` downloads and boots the latest `juspay/devbox` GitHub release
 
 The VM name is `devbox`, and the guest user defaults to your macOS `$USER`. CPU / memory / disk default to `host cores − 2`, `host RAM − 4 GiB`, and `half of host free disk`. Memory is a ceiling (the vz driver demand-pages from the host); disk is a ceiling (Lima's qcow2 is sparse and grows lazily); CPU over-subscription is cheap. Override any default with `just --set`, e.g. `just --set cpus 4 --set memory 16 --set disk 200 start`.
 
+## Direct Lima usage
+
+You can use the published image without Nix or this repo's `justfile`:
+
+```sh
+limactl start --name=devbox https://github.com/juspay/devbox/releases/latest/download/devbox-lima.yaml
+limactl shell --workdir=. devbox
+```
+
+Use `--workdir=.` when opening a shell. The template intentionally has a transfer mount, so plain `limactl shell devbox` makes Lima try to enter your macOS current directory inside the guest. That path is not mounted.
+
 ## What's in the VM
 
 Via [`nixos/devbox.nix`](nixos/devbox.nix): `nix-ld`, flakes, [`nixos-vscode-server`](https://github.com/nix-community/nixos-vscode-server), `starship`, `direnv` + `nix-direnv`, `btop`, `just`, `gh`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ just recreate     # wipe and start fresh
 just list         # list all Lima VMs
 ```
 
-First `just start` downloads and boots the latest `juspay/devbox` GitHub release template. That template keeps the locked `nixos-lima` defaults for mounts, memory, and port forwarding, and points at the matching devbox qcow2 assets with SHA-512 digests.
+First `just start` downloads and boots the latest `juspay/devbox` GitHub release template. That template keeps the locked `nixos-lima` integration defaults, points at the matching devbox qcow2 assets with SHA-512 digests, and mounts only `/tmp/lima-devbox` from the host for intentional file transfer.
 
 The VM name is `devbox`, and the guest user defaults to your macOS `$USER`. CPU / memory / disk default to `host cores − 2`, `host RAM − 4 GiB`, and `half of host free disk`. Memory is a ceiling (the vz driver demand-pages from the host); disk is a ceiling (Lima's qcow2 is sparse and grows lazily); CPU over-subscription is cheap. Override any default with `just --set`, e.g. `just --set cpus 4 --set memory 16 --set disk 200 start`.
 
@@ -79,7 +79,7 @@ docs: document release workflow
 
 This is a local, single-user devbox VM, not a hardened multi-user host. The passwordless sudo behavior comes from `nixos-lima`: `lima-init` creates a guest user matching your macOS `$USER` and adds it to `wheel`, while the `nixos-lima` module sets `security.sudo.wheelNeedsPassword = false`. This repo currently keeps that behavior.
 
-SSH access uses Lima's generated config under `~/.lima/devbox/ssh.config`, so this repo does not mutate your global `~/.ssh/config`. Your macOS home is mounted into the guest at `/Users/<you>` read-only; keep day-to-day development work in the guest's own writable filesystem, such as `~/code`.
+SSH access uses Lima's generated config under `~/.lima/devbox/ssh.config`, so this repo does not mutate your global `~/.ssh/config`. The VM does not mount your macOS home directory. The only default host mount is `/tmp/lima-devbox`, mounted writable at the same path in the guest so you can intentionally transfer files across the boundary. Treat it as a scratch exchange directory, not a workspace or secrets store.
 
 ## Installing more tools
 
@@ -106,7 +106,7 @@ That's the whole setup. Subsequent connects are one command.
 
 ## Working on projects inside the VM
 
-Lima mounts your macOS home at `/Users/<you>` inside the guest **read-only**. For development, clone repos into the guest's own filesystem (writable, faster, no 9p overhead):
+For development, clone repos into the guest's own filesystem (writable, faster, no 9p overhead):
 
 ```sh
 just ssh
@@ -114,4 +114,4 @@ mkdir -p ~/code && cd ~/code
 git clone …
 ```
 
-The mount's read-only state is the Lima default; we keep it. If you want to override it (or anything else in the template), [`flake.nix`](flake.nix) has a `yq`-based pattern commented next to the `lima-template` derivation.
+To move files between macOS and the VM, use `/tmp/lima-devbox` on either side. It is the only default host path exposed to the guest.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run `nix develop` once to enter a shell with `lima`, `just`, and `gh` pinned, or
 just              # list recipes
 just start        # create + boot the VM from the latest release image
 just start dev    # create + boot the VM from the mutable dev release image
-just shell        # open a shell in the VM
+just shell        # open a shell in the VM, starting in the guest home
 just stop         # stop the VM
 just delete       # remove the VM
 just delete-downloaded-images dev # clear cached Lima image downloads for dev

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,18 @@
       darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
       forEach = nixpkgs.lib.genAttrs;
       base = import ./default.nix inputs;
+      limaMessage = ''
+        devbox is ready.
+
+        Open a shell:
+          limactl shell --workdir=. {{.Name}}
+
+        This template intentionally does not mount your macOS home directory.
+        Clone repositories inside the VM, for example under ~/code.
+
+        To transfer files intentionally, use /tmp/lima-devbox on the host and
+        inside the VM.
+      '';
     in
     base // {
       devShells = forEach systems (system:
@@ -47,6 +59,7 @@
         let pkgs = nixpkgs.legacyPackages.${system}; in {
           lima-template = pkgs.runCommand "devbox-lima-template" {
             nativeBuildInputs = [ pkgs.yq-go ];
+            DEVBOX_MESSAGE = limaMessage;
           } ''
             yq -P '
               .mounts = [
@@ -59,6 +72,7 @@
                   }
                 }
               ]
+              | .message = strenv(DEVBOX_MESSAGE)
             ' ${nixos-lima}/.lima.yaml > $out
           '';
         });

--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,26 @@
           };
         });
 
-      # Lima template YAML, pinned to our locked nixos-lima input. Passes
-      # through unmodified today; to apply local overrides (e.g. writable
-      # mounts), swap the `cp` for a `yq` transform, for example:
-      #   nativeBuildInputs = [ pkgs.yq-go ];
-      #   yq '.mounts |= map(.writable = true)' ${nixos-lima}/.lima.yaml > $out
+      # Lima template YAML, pinned to our locked nixos-lima input. Keep the
+      # nixos-lima guest integration defaults, but replace broad host mounts
+      # with a narrow scratch directory for explicit file transfer.
       packages = forEach systems (system:
         let pkgs = nixpkgs.legacyPackages.${system}; in {
-          lima-template = pkgs.runCommand "nixos-lima-template" { } ''
-            cp ${nixos-lima}/.lima.yaml $out
+          lima-template = pkgs.runCommand "devbox-lima-template" {
+            nativeBuildInputs = [ pkgs.yq-go ];
+          } ''
+            yq -P '
+              .mounts = [
+                {
+                  "location": "/tmp/lima-devbox",
+                  "mountPoint": "/tmp/lima-devbox",
+                  "writable": true,
+                  "9p": {
+                    "cache": "mmap"
+                  }
+                }
+              ]
+            ' ${nixos-lima}/.lima.yaml > $out
           '';
         });
     };

--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ list:
 # Open a shell in the VM
 [group('access')]
 shell:
-    {{nix_shell}} limactl shell {{name}}
+    {{nix_shell}} limactl shell --workdir=. {{name}}
 
 # Print Lima's generated SSH config for the VM
 [group('access')]

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ start release="latest":
     else
       template_url="https://github.com/juspay/devbox/releases/download/$release/devbox-lima.yaml"
     fi
+    mkdir -p /tmp/lima-devbox
     {{nix_shell}} limactl start --name={{name}} --cpus={{cpus}} --memory={{memory}} --disk={{disk}} --yes "$template_url"
 
 # Delete Lima's downloaded devbox image cache for a release


### PR DESCRIPTION
## Summary

- replace the inherited nixos-lima broad host mounts with a single writable `/tmp/lima-devbox` transfer mount in the generated Lima template
- create `/tmp/lima-devbox` before `just start` so the scratch mount exists on fresh hosts
- start `just shell` in the guest home so Lima does not try to cd into an unmounted macOS path
- add a Lima template startup message and README direct-use instructions for users who run the published image without Nix or `just`
- update README security and workflow guidance to say macOS home is not mounted and repos should be cloned inside the VM

Closes #12.

## Validation

- `nix build --no-link --print-out-paths .#lima-template`
- `limactl validate $(nix build --no-link --print-out-paths .#lima-template)`
- inspected the generated template `message`
- simulated the release template image rewrite and validated the generated YAML/message
- `nix develop -c limactl shell --workdir=. devbox pwd`
- `nix flake check --show-trace`
- `just --summary`
- `git diff --check`
