### PR TITLE
feat(website): add social preview card, favicon, and refresh tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixden
 
-NixOS based nixden on macOS — a [`justfile`](justfile) + flake that boots and provisions a customized NixOS VM via [Lima](https://lima-vm.io/).
+Isolated NixOS-based devbox for Mac users and others — a [`justfile`](justfile) + flake that boots and provisions a customized NixOS VM via [Lima](https://lima-vm.io/).
 
 ## Requirements
 

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="nixden">
+  <rect width="64" height="64" rx="12" fill="#f1ebdd"/>
+  <text x="18" y="50" font-family="'Fraunces', 'Times New Roman', Georgia, serif" font-style="italic" font-weight="500" font-size="48" letter-spacing="-2" fill="#141210">n</text>
+  <circle cx="50" cy="46" r="4" fill="#c14a1b"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -4,6 +4,25 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>nixden — prebuilt NixOS on Lima</title>
+    <meta name="description" content="A prebuilt NixOS VM on Lima. One command boots a clean, throwaway dev environment on macOS — flakes, direnv, gh, just, all ready.">
+    <link rel="canonical" href="https://juspay.github.io/nixden/">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="nixden">
+    <meta property="og:title" content="nixden — prebuilt NixOS on Lima">
+    <meta property="og:description" content="A prebuilt NixOS VM on Lima. One command boots a clean, throwaway dev environment on macOS — flakes, direnv, gh, just, all ready.">
+    <meta property="og:url" content="https://juspay.github.io/nixden/">
+    <meta property="og:image" content="https://juspay.github.io/nixden/og.svg">
+    <meta property="og:image:alt" content="nixden — a NixOS VM, ready to run.">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="nixden — prebuilt NixOS on Lima">
+    <meta name="twitter:description" content="A prebuilt NixOS VM on Lima. One command boots a clean, throwaway dev environment on macOS.">
+    <meta name="twitter:image" content="https://juspay.github.io/nixden/og.svg">
+    <meta name="twitter:image:alt" content="nixden — a NixOS VM, ready to run.">
+
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..900,0..100;1,9..144,300..900,0..100&family=JetBrains+Mono:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">

--- a/site/og.svg
+++ b/site/og.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="nixden — prebuilt NixOS on Lima">
+  <defs>
+    <filter id="grain" x="0" y="0" width="100%" height="100%">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+      <feColorMatrix values="0 0 0 0 0.08  0 0 0 0 0.07  0 0 0 0 0.05  0 0 0 0.14 0"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="630" fill="#f1ebdd"/>
+
+  <!-- hairline grid -->
+  <g stroke="#141210" stroke-opacity="0.045" stroke-width="1">
+    <line x1="300" y1="0" x2="300" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/>
+    <line x1="900" y1="0" x2="900" y2="630"/>
+  </g>
+
+  <!-- paper grain -->
+  <rect width="1200" height="630" filter="url(#grain)" opacity="0.4" style="mix-blend-mode:multiply"/>
+
+  <!-- masthead rule + meta -->
+  <line x1="72" y1="96" x2="1128" y2="96" stroke="#141210" stroke-width="1"/>
+  <text x="72" y="76" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="15" letter-spacing="2.4" fill="#6b5f52">NIXDEN &#160;&#183;&#160; VOL. 01 &#160;&#183;&#160; PREBUILT NIXOS &#160;&#183;&#160; RUNTIME LIMA</text>
+
+  <!-- eyebrow -->
+  <line x1="72" y1="196" x2="112" y2="196" stroke="#c14a1b" stroke-width="1"/>
+  <text x="128" y="201" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" letter-spacing="4" fill="#c14a1b">PREBUILT NIXOS ON LIMA</text>
+
+  <!-- wordmark -->
+  <text x="72" y="420" font-family="'Fraunces', 'Times New Roman', Georgia, serif" font-style="italic" font-weight="400" font-size="248" letter-spacing="-8" fill="#141210">nix<tspan fill="#c14a1b">den</tspan></text>
+
+  <!-- lead -->
+  <text x="76" y="488" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#2a2520">A NixOS VM, ready to run.</text>
+
+  <!-- bottom rule + meta -->
+  <line x1="72" y1="548" x2="1128" y2="548" stroke="#141210" stroke-width="1"/>
+  <text x="72" y="580" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12" letter-spacing="2.8" fill="#6b5f52">JUSPAY &#160;/&#160; NIXDEN</text>
+  <text x="1128" y="580" text-anchor="end" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12" letter-spacing="2.8" fill="#6b5f52">&#167; 01</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add OGP + Twitter Card meta tags, canonical URL, and `meta description` to `site/index.html`
- Add `site/og.svg` — 1200×630 editorial card matching the site's paper/ink/orange theme, used for `og:image` / `twitter:image`
- Add `site/favicon.svg` — compact italic-`n` monogram with orange accent, wired via `<link rel="icon">`
- Update README first paragraph to the new project tagline: *Isolated NixOS-based devbox for Mac users and others*

## Preview

![nixden social card](https://raw.githubusercontent.com/juspay/nixden/feat/social-preview/site/og.svg)

## Notes

- `og.svg` and `favicon.svg` reference Fraunces with a `Times New Roman` / Georgia serif fallback; standalone SVG renderers (including GitHub's) can't fetch web fonts, so the card renders with the system serif. The site itself still loads Fraunces via the existing stylesheet.
- SVG `og:image` renders on GitHub, Slack, Discord, and LinkedIn. Twitter/X and Facebook currently require raster (PNG/JPEG) — a follow-up can ship a rasterized `og.png` if those platforms matter.

## Test plan

- [ ] Open `site/index.html` locally; verify favicon appears in the tab
- [ ] After deploy, paste `https://juspay.github.io/nixden/` into https://www.opengraph.xyz/ and confirm title, description, and card image
- [ ] Confirm Slack / Discord unfurls render the SVG card

🤖 Generated with [Claude Code](https://claude.com/claude-code)