### PR TITLE
fix(justfile): detect host CPU and memory on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixden
 
-Isolated NixOS-based devbox for Mac users and others — a [`justfile`](justfile) + flake that boots and provisions a customized NixOS VM via [Lima](https://lima-vm.io/).
+Isolated NixOS-based devbox for macOS and Linux hosts — a [`justfile`](justfile) + flake that boots and provisions a customized NixOS VM via [Lima](https://lima-vm.io/).
 
 ## Requirements
 

--- a/justfile
+++ b/justfile
@@ -4,12 +4,20 @@ name := "nixden"
 # CPUs = host logical cores − 2 (leave a couple for the host). CPU
 # over-subscription is cheap — the host scheduler time-slices — so we
 # can be generous. Override: `just --set cpus 4 start`.
-cpus := `echo $(( $(sysctl -n hw.ncpu) - 2 ))`
+cpus := if os() == "macos" {
+  `echo $(( $(sysctl -n hw.ncpu) - 2 ))`
+} else {
+  `echo $(( $(nproc) - 2 ))`
+}
 
 # Memory ceiling in GiB = host RAM − 4 GiB. With the vz driver the host
 # demand-pages guest memory, so this is a cap, not an up-front allocation.
 # Override: `just --set memory 16 start`.
-memory := `echo $(( $(sysctl -n hw.memsize) / 1073741824 - 4 ))`
+memory := if os() == "macos" {
+  `echo $(( $(sysctl -n hw.memsize) / 1073741824 - 4 ))`
+} else {
+  `echo $(( $(awk '/MemTotal:/ { print $2 }' /proc/meminfo) / 1024 / 1024 - 4 ))`
+}
 
 # Disk ceiling in GiB = half of host root-fs free space. Lima's qcow2 is
 # sparse, so the image only grows as the guest writes.

--- a/site/index.html
+++ b/site/index.html
@@ -728,6 +728,10 @@
             <summary>Running x86_64 binaries on Apple Silicon</summary>
             <p>Rosetta is on by default, so the aarch64 guest runs x86_64 Linux binaries at near-native speed via <code>binfmt_misc</code> — just <code>./some-x86-binary</code> and it works. Requires macOS 13+ on Apple Silicon and the <code>vz</code> driver.</p>
           </details>
+          <details>
+            <summary>Linux hosts</summary>
+            <p>nixden targets macOS first, but the same starter and <code>just</code> flow run on Linux hosts wherever Lima is supported — see the <a href="https://lima-vm.io/docs/installation/">Lima installer guide</a>.</p>
+          </details>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Running `just` on a Linux host crashed before any recipe ran because the `cpus` / `memory` defaults shelled out to `sysctl -n hw.ncpu` / `sysctl -n hw.memsize`. Branch on `os()` so Linux uses `nproc` and `/proc/meminfo`; macOS keeps `sysctl`.
- `disk` already used `df -k /`, which is portable, so no change there.
- Tagline updated to call out Linux as a supported host (the `site/start` script already detected Linux; this brings the in-repo `just` flow to parity).

## Test plan
- [x] `just --evaluate cpus` / `memory` / `disk` resolve on Linux (this branch)
- [x] `just` lists recipes on Linux
- [ ] Sanity-check on macOS that `os() == "macos"` still selects the `sysctl` branch